### PR TITLE
Choose WAL-G backup by start time when cloning and deleting

### DIFF
--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -19,7 +19,7 @@ FROM $BASE_IMAGE as dependencies-builder
 
 ARG DEMO
 
-ENV WALG_VERSION=v3.0.0
+ENV WALG_VERSION=v3.0.3
 
 COPY build_scripts/dependencies.sh /builddeps/
 

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -19,7 +19,7 @@ FROM $BASE_IMAGE as dependencies-builder
 
 ARG DEMO
 
-ENV WALG_VERSION=v2.0.1
+ENV WALG_VERSION=v3.0.0
 
 COPY build_scripts/dependencies.sh /builddeps/
 

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -19,7 +19,7 @@ FROM $BASE_IMAGE as dependencies-builder
 
 ARG DEMO
 
-ENV WALG_VERSION=fix-libsodium
+ENV WALG_VERSION=v3.0.0
 
 COPY build_scripts/dependencies.sh /builddeps/
 

--- a/postgres-appliance/Dockerfile
+++ b/postgres-appliance/Dockerfile
@@ -19,7 +19,7 @@ FROM $BASE_IMAGE as dependencies-builder
 
 ARG DEMO
 
-ENV WALG_VERSION=v3.0.0
+ENV WALG_VERSION=fix-libsodium
 
 COPY build_scripts/dependencies.sh /builddeps/
 

--- a/postgres-appliance/bootstrap/clone_with_wale.py
+++ b/postgres-appliance/bootstrap/clone_with_wale.py
@@ -72,7 +72,7 @@ def choose_backup(backup_list, recovery_target_time):
 
     match_timestamp = match = None
     for backup in backup_list:
-        last_modified = parse(backup['start_time' if os.getenv('USE_WALG_RESTORE') == 'true' else 'last_modified'])
+        last_modified = parse(backup['finish_time' if os.getenv('USE_WALG_RESTORE') == 'true' else 'last_modified'])
         if last_modified < recovery_target_time:
             if match is None or last_modified > match_timestamp:
                 match = backup

--- a/postgres-appliance/bootstrap/clone_with_wale.py
+++ b/postgres-appliance/bootstrap/clone_with_wale.py
@@ -60,8 +60,7 @@ def fix_output(output):
     started = None
     for line in output.decode('utf-8').splitlines():
         if not started:
-            started = re.match(r'^name\s+last_modified\s+', line)
-            started = re.match(r'^name\s+last_modified\s+', line) or re.match(r'^name\s+modified\s+', line)
+            started = re.match(r'^(backup_)?name\s+(last_)?modified\s+', line)
             if started:
                 line = line.replace(' modified ', ' last_modified ')
         if started:
@@ -79,7 +78,7 @@ def choose_backup(backup_list, recovery_target_time):
                 match = backup
                 match_timestamp = last_modified
     if match is not None:
-        return match['backup_name' if os.getenv('USE_WALG_RESTORE') == 'true' else 'name']
+        return match.get('name', match['backup_name'])
 
 
 def list_backups(env):

--- a/postgres-appliance/bootstrap/clone_with_wale.py
+++ b/postgres-appliance/bootstrap/clone_with_wale.py
@@ -2,6 +2,7 @@
 
 import argparse
 import csv
+import json
 import logging
 import os
 import re
@@ -40,7 +41,7 @@ def read_configuration():
     return options(args.scope, args.datadir, recovery_target_time, args.dry_run)
 
 
-def build_wale_command(command, datadir=None, backup=None):
+def build_wale_command(command, datadir=None, backup=None, extra_args=None):
     cmd = ['wal-g' if os.getenv('USE_WALG_RESTORE') == 'true' else 'wal-e'] + [command]
     if command == 'backup-fetch':
         if datadir is None or backup is None:
@@ -48,6 +49,8 @@ def build_wale_command(command, datadir=None, backup=None):
         cmd.extend([datadir, backup])
     elif command != 'backup-list':
         raise Exception("invalid {0} command {1}".format(cmd[0], command))
+    if extra_args:
+        cmd.extend(extra_args)
     return cmd
 
 
@@ -70,20 +73,25 @@ def choose_backup(backup_list, recovery_target_time):
 
     match_timestamp = match = None
     for backup in backup_list:
-        last_modified = parse(backup['last_modified'])
+        last_modified = parse(backup['start_time' if os.getenv('USE_WALG_RESTORE') == 'true' else 'last_modified'])
         if last_modified < recovery_target_time:
             if match is None or last_modified > match_timestamp:
                 match = backup
                 match_timestamp = last_modified
     if match is not None:
-        return match['name']
+        return match['backup_name' if os.getenv('USE_WALG_RESTORE') == 'true' else 'name']
 
 
 def list_backups(env):
-    backup_list_cmd = build_wale_command('backup-list')
-    output = subprocess.check_output(backup_list_cmd, env=env)
-    reader = csv.DictReader(fix_output(output), dialect='excel-tab')
-    return list(reader)
+    if os.getenv('USE_WALG_RESTORE') == 'true':
+        backup_list_cmd = build_wale_command('backup-list', extra_args=['--detail', '--json'])
+        output = subprocess.check_output(backup_list_cmd, env=env)
+        return json.loads(output or 'null')
+    else:
+        backup_list_cmd = build_wale_command('backup-list')
+        output = subprocess.check_output(backup_list_cmd, env=env)
+        reader = csv.DictReader(fix_output(output), dialect='excel-tab')
+        return list(reader)
 
 
 def get_clone_envdir():

--- a/postgres-appliance/build_scripts/dependencies.sh
+++ b/postgres-appliance/build_scripts/dependencies.sh
@@ -29,7 +29,7 @@ apt-get update
 apt-get install -y golang-go liblzo2-dev brotli libsodium-dev git make cmake gcc libc-dev
 go version
 
-git clone -b "$WALG_VERSION" --recurse-submodules https://github.com/wal-g/wal-g.git
+git clone -b "$WALG_VERSION" --recurse-submodules https://github.com/garry-t/wal-g.git
 cd /wal-g
 go get -v -t -d ./...
 go mod vendor

--- a/postgres-appliance/build_scripts/dependencies.sh
+++ b/postgres-appliance/build_scripts/dependencies.sh
@@ -29,7 +29,7 @@ apt-get update
 apt-get install -y golang-go liblzo2-dev brotli libsodium-dev git make cmake gcc libc-dev
 go version
 
-git clone -b "$WALG_VERSION" --recurse-submodules https://github.com/garry-t/wal-g.git
+git clone -b "$WALG_VERSION" --recurse-submodules https://github.com/wal-g/wal-g.git
 cd /wal-g
 go get -v -t -d ./...
 go mod vendor

--- a/postgres-appliance/scripts/wale_restore.sh
+++ b/postgres-appliance/scripts/wale_restore.sh
@@ -43,7 +43,7 @@ ATTEMPT=0
 server_version="-1"
 while true; do
     [[ -z $wal_segment_backup_start ]] && wal_segment_backup_start=$($WAL_E backup-list 2> /dev/null \
-        | sed '0,/^name\s*\(last_\)\?modified\s*/d' | sort -bk2 | tail -n1 | awk '{print $3;}' | sed 's/_.*$//')
+        | sed '0,/^(backup_\)?name\s*\(last_\)\?modified\s*/d' | sort -bk2 | tail -n1 | awk '{print $3;}' | sed 's/_.*$//')
 
     [[ -n "$CONNSTR" && $server_version == "-1" ]] && server_version=$(psql -d "$CONNSTR" -tAc 'show server_version_num' 2> /dev/null || echo "-1")
 


### PR DESCRIPTION
Fixes https://github.com/elastisys/compliantkubernetes-postgresql/issues/241

Also fixes the following upstream issues AFAIK (more investigation needed to verify):
* Bump wal-g v3:
  * https://github.com/zalando/spilo/issues/986
* Restore issues:
  * https://github.com/zalando/spilo/issues/576
  * https://github.com/zalando/spilo/issues/652
* Clean up issues:
  * https://github.com/zalando/spilo/issues/937
  * https://github.com/zalando/spilo/issues/425
  * https://github.com/zalando/spilo/issues/879

Does not fix when Spilo relies on `wal-g backup-list LATEST`:
  * https://github.com/wal-g/wal-g/issues/694
  * https://github.com/wal-g/wal-g/issues/1108

Breaks cloning from backup that does not include `metadata.json` (for example backup created with `wal-e`):
  * https://github.com/wal-g/wal-g/issues/556