### PR TITLE
Choose WAL-G backup by start time when cloning and deleting

### DIFF
--- a/postgres-appliance/bootstrap/clone_with_wale.py
+++ b/postgres-appliance/bootstrap/clone_with_wale.py
@@ -72,7 +72,7 @@ def choose_backup(backup_list, recovery_target_time):
 
     match_timestamp = match = None
     for backup in backup_list:
-        last_modified = parse(backup['start_time' if os.getenv('USE_WALG_RESTORE') == 'true' else 'last_modified'])
+        last_modified = parse(backup['finish_time' if os.getenv('USE_WALG_RESTORE') == 'true' else 'last_modified'])
         if last_modified < recovery_target_time:
             if match is None or last_modified > match_timestamp:
                 match = backup

--- a/postgres-appliance/scripts/postgres_backup.sh
+++ b/postgres-appliance/scripts/postgres_backup.sh
@@ -39,29 +39,31 @@ else
     POOL_SIZE=(--pool-size "$POOL_SIZE")
 fi
 
-BEFORE=""
-LEFT=0
-
 NOW=$(date +%s -u)
 readonly NOW
-while read -r name last_modified rest; do
-    last_modified=$(date +%s -ud "$last_modified")
-    if [ $(((NOW-last_modified)/86400)) -ge $DAYS_TO_RETAIN ]; then
-        if [ -z "$BEFORE" ] || [ "$last_modified" -gt "$BEFORE_TIME" ]; then
-            BEFORE_TIME=$last_modified
-            BEFORE=$name
-        fi
-    else
-        # count how many backups will remain after we remove everything up to certain date
-        ((LEFT=LEFT+1))
-    fi
-done < <($WAL_E backup-list 2> /dev/null | sed '0,/^\(backup_\)\?name\s*\(last_\)\?modified\s*/d')
 
-# we want keep at least N backups even if the number of days exceeded
-if [ -n "$BEFORE" ] && [ $LEFT -ge $DAYS_TO_RETAIN ]; then
-    if [[ "$USE_WALG_BACKUP" == "true" ]]; then
-        $WAL_E delete before FIND_FULL "$BEFORE" --confirm
-    else
+if [[ "$USE_WALG_BACKUP" == "true" ]]; then
+    AFTER=$((NOW-(DAYS_TO_RETAIN*86400)))
+    $WAL_E delete --use-sentinel-time --confirm retain FIND_FULL "$DAYS_TO_RETAIN" --after "$(date --iso-8601=seconds -d @"${AFTER}")"
+else
+    BEFORE=""
+    LEFT=0
+
+    while read -r name last_modified rest; do
+        last_modified=$(date +%s -ud "$last_modified")
+        if [ $(((NOW-last_modified)/86400)) -ge $DAYS_TO_RETAIN ]; then
+            if [ -z "$BEFORE" ] || [ "$last_modified" -gt "$BEFORE_TIME" ]; then
+                BEFORE_TIME=$last_modified
+                BEFORE=$name
+            fi
+        else
+            # count how many backups will remain after we remove everything up to certain date
+            ((LEFT=LEFT+1))
+        fi
+    done < <($WAL_E backup-list 2> /dev/null | sed '0,/^name\s*\(last_\)\?modified\s*/d')
+
+    # we want keep at least N backups even if the number of days exceeded
+    if [ -n "$BEFORE" ] && [ $LEFT -ge $DAYS_TO_RETAIN ]; then
         $WAL_E delete --confirm before "$BEFORE"
     fi
 fi


### PR DESCRIPTION
This replaces #1 with a rebased commit stack.

Fixes https://github.com/elastisys/compliantkubernetes-postgresql/issues/241

Also fixes the following upstream issues AFAIK (more investigation needed to verify):
* Bump wal-g v3:
  * https://github.com/zalando/spilo/issues/986
* Restore issues:
  * https://github.com/zalando/spilo/issues/576
  * https://github.com/zalando/spilo/issues/652
* Clean up issues:
  * https://github.com/zalando/spilo/issues/937
  * https://github.com/zalando/spilo/issues/425
  * https://github.com/zalando/spilo/issues/879

Does not fix when Spilo relies on `wal-g backup-list LATEST`:
  * https://github.com/wal-g/wal-g/issues/694
  * https://github.com/wal-g/wal-g/issues/1108

Breaks cloning from backup that does not include `metadata.json` (for example backup created with `wal-e`):
  * https://github.com/wal-g/wal-g/issues/556
