### PR TITLE
Fix file permission when restoring pg

### DIFF
--- a/postgres-appliance/bootstrap/maybe_pg_upgrade.py
+++ b/postgres-appliance/bootstrap/maybe_pg_upgrade.py
@@ -32,6 +32,7 @@ def perform_pitr(postgresql, cluster_version, bin_version, config):
     config[config['method']]['command'] = 'true'
     try:
         if bin_version == cluster_version:
+            os.chmod('/home/postgres/pgdata/pgroot/data', 0o700)
             if not postgresql.bootstrap.bootstrap(config):
                 raise Exception('Point-in-time recovery failed')
         elif not postgresql.start_old_cluster(config, cluster_version):


### PR DESCRIPTION
We ran into an issue where the `data` dir got the wrong permissions when restoring postgres from physical backups

```console
2025-08-07 13:49:55,916 maybe_pg_upgrade INFO: Trying to perform point-in-time recovery
2025-08-07 13:49:55,916 maybe_pg_upgrade INFO: Running custom bootstrap script: true
2025-08-07 13:49:56 UTC [100]: [1-1] 6894af04.64 0     FATAL:  data directory "/home/postgres/pgdata/pgroot/data" has invalid permissions
2025-08-07 13:49:56 UTC [100]: [2-1] 6894af04.64 0     DETAIL:  Permissions should be u=rwx (0700) or u=rwx,g=rx (0750).
2025-08-07 13:49:56,277 maybe_pg_upgrade INFO: postmaster pid=100
/var/run/postgresql:5432 - no response
2025-08-07 13:49:57,284 maybe_pg_upgrade ERROR: postmaster is not running
Traceback (most recent call last):
  File "/scripts/maybe_pg_upgrade.py", line 36, in perform_pitr
    raise Exception('Point-in-time recovery failed')
Exception: Point-in-time recovery failed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/scripts/maybe_pg_upgrade.py", line 125, in <module>
    main()
  File "/scripts/maybe_pg_upgrade.py", line 72, in main
    perform_pitr(upgrade, cluster_version, bin_version, config['bootstrap'])
  File "/scripts/maybe_pg_upgrade.py", line 55, in perform_pitr
    raise Exception('Point-in-time recovery failed.\nLOGS:\n--\n' + logs)
Exception: Point-in-time recovery failed.
LOGS:
--

2025-08-07 13:49:57,319 ERROR: /scripts/maybe_pg_upgrade.py script failed
```

Tried using different storageclass (volume type), changing securitycontext on the pods (fsGroup, fsGroupChangePolicy) but that made no difference.
